### PR TITLE
fix(auth): resolve OTP verification and add email logging

### DIFF
--- a/src/EVServiceCenter.Api/Data/lockout_data.json
+++ b/src/EVServiceCenter.Api/Data/lockout_data.json
@@ -1,8 +1,1 @@
-{
-  "vominhtien051124@gmail.com": {
-    "Email": "vominhtien051124@gmail.com",
-    "FailedAttempts": 1,
-    "FirstFailedAttempt": "2025-10-04T13:45:40.2648776Z",
-    "LockoutUntil": null
-  }
-}
+{}

--- a/src/EVServiceCenter.Application/Service/AuthService.cs
+++ b/src/EVServiceCenter.Application/Service/AuthService.cs
@@ -667,7 +667,7 @@ namespace EVServiceCenter.Application.Service
             var user = await _accountRepository.GetAccountByEmailAsync(email);
             if (user == null) throw new Exception("Người dùng không tồn tại.");
 
-            var lastOtp = await _otpRepository.GetLastOtpCodeAsync(user.UserId, "Register");
+            var lastOtp = await _otpRepository.GetLastOtpCodeAsync(user.UserId, "EMAIL_VERIFICATION");
             if (lastOtp == null) throw new Exception("Không tìm thấy mã OTP.");
 
             if (lastOtp.IsUsed || lastOtp.ExpiresAt < DateTime.UtcNow)

--- a/src/EVServiceCenter.Application/Service/EmailService.cs
+++ b/src/EVServiceCenter.Application/Service/EmailService.cs
@@ -131,13 +131,20 @@ namespace EVServiceCenter.Application.Service
         {
             try
             {
+                // Log OTP code to console for debugging
+                Console.WriteLine($"🔐 OTP CODE FOR {toEmail}: {otpCode}");
+                Console.WriteLine($"📧 Sending verification email to: {toEmail}");
+                
                 var subject = "Xác thực tài khoản EV Service Center";
                 var body = CreateVerificationEmailTemplate(fullName, otpCode);
                 
                 await SendEmailAsync(toEmail, subject, body);
+                
+                Console.WriteLine($"✅ Verification email sent successfully to: {toEmail}");
             }
             catch (Exception ex)
             {
+                Console.WriteLine($"❌ Failed to send verification email to {toEmail}: {ex.Message}");
                 throw new Exception($"Không thể gửi email xác thực: {ex.Message}");
             }
         }


### PR DESCRIPTION
- Fix OTP type mismatch in VerifyOtpAsync (Register -> EMAIL_VERIFICATION)
- Add console logging for OTP codes in EmailService
- Add detailed email sending logs for debugging
- Fix AuthServiceTests to include ILoginLockoutService mock
- Ensure OTP verification works correctly with proper type matching

Resolves: OTP verification errors and missing email debugging info